### PR TITLE
Enabling CallBuilder cascade method calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+# Filter out all compiled Manifest files
+**/*.rtm
+
+# 
+.DS_Store

--- a/test-engine/src/account.rs
+++ b/test-engine/src/account.rs
@@ -6,7 +6,7 @@ use radix_engine_interface::types::ComponentAddress;
 
 use crate::engine_interface::EngineInterface;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Account {
     component_address: ComponentAddress,
     public_key: Secp256k1PublicKey,

--- a/test-engine/tests/nft_marketplace/unit_tests.rs
+++ b/test-engine/tests/nft_marketplace/unit_tests.rs
@@ -82,7 +82,7 @@ mod nft_marketplace_tests {
         test_engine.jump_epochs(5);
         let amount_owned_before = test_engine.current_balance("xrd");
         test_engine
-            .call_chainable_method(
+            .call(
                 "buy",
                 env_args![Environment::FungibleBucket("xrd", dec!(10))],
             )

--- a/test-engine/tests/nft_marketplace/unit_tests.rs
+++ b/test-engine/tests/nft_marketplace/unit_tests.rs
@@ -82,7 +82,7 @@ mod nft_marketplace_tests {
         test_engine.jump_epochs(5);
         let amount_owned_before = test_engine.current_balance("xrd");
         test_engine
-            .custom_method_call(
+            .call_chainable_method(
                 "buy",
                 env_args![Environment::FungibleBucket("xrd", dec!(10))],
             )


### PR DESCRIPTION
This PR contains somme update to allow CallBuilder methods to be call in chain before execution.